### PR TITLE
Update GiftedChat.js

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -195,6 +195,7 @@ class GiftedChat extends React.Component {
       <div style={{
         height: `calc(100% - ${this.state.composerHeight}px)`,
         display: 'flex',
+        flexDirection: 'column'
       }}
       >
         <MessageContainer


### PR DESCRIPTION
[Bug Fix] renderChatFooter was aligned with MessageContainer row-wise earlier. Added "flex-direction:column" to parent div.